### PR TITLE
Make linenoise an option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,6 @@ endif()
 
 add_definitions(-DBOOST_CHRONO_HEADER_ONLY -DBOOST_NO_AUTO_PTR)
 
-
 #############################################
 # Detect CCache
 
@@ -216,6 +215,12 @@ else()
     option(SC_HIDAPI "Build with HID support" ON)
 endif()
 
+if(WIN32)
+    option(SC_LINENOISE "Use linenoise instead of readline" ON)
+else(WIN32)
+    option(SC_LINENOISE "Use linenoise instead of readline" OFF)
+endif(WIN32)
+
 #############################################
 # some default libraries
 
@@ -244,6 +249,11 @@ if(SYSTEM_YAMLCPP)
 else()
   set(YAMLCPP_FOUND OFF)
 endif()
+
+if(SC_LINENOISE)
+	add_definitions(-DUSE_LINENOISE)
+	message(STATUS "Using library linenoise-ng for command line mode")
+endif(SC_LINENOISE)
 
 #############################################
 # some preprocessor flags

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -18,10 +18,16 @@ include_directories(${CMAKE_SOURCE_DIR}/include/common
                     LangPrimSource
 
                     ${CMAKE_SOURCE_DIR}/external_libraries/nova-tt
-                    ${CMAKE_SOURCE_DIR}/external_libraries/linenoise-ng/include
                     LangSource/Bison
 )
 
+if(SC_LINENOISE)
+	include_directories(
+		${CMAKE_SOURCE_DIR}/external_libraries/linenoise-ng/include
+	)
+else()
+	find_package(Readline)
+endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 	find_package(ALSA)
@@ -87,11 +93,16 @@ set(sclang_sources
 
 	${CMAKE_SOURCE_DIR}/common/sc_popen.cpp
 
-	${CMAKE_SOURCE_DIR}/external_libraries/linenoise-ng/src/ConvertUTF.cpp
-	${CMAKE_SOURCE_DIR}/external_libraries/linenoise-ng/src/linenoise.cpp
-	${CMAKE_SOURCE_DIR}/external_libraries/linenoise-ng/src/wcwidth.cpp
-
 )
+
+if(SC_LINENOISE)
+	set(sclang_sources
+		${sclang_sources}
+		${CMAKE_SOURCE_DIR}/external_libraries/linenoise-ng/src/ConvertUTF.cpp
+		${CMAKE_SOURCE_DIR}/external_libraries/linenoise-ng/src/linenoise.cpp
+		${CMAKE_SOURCE_DIR}/external_libraries/linenoise-ng/src/wcwidth.cpp
+	)
+endif(SC_LINENOISE)
 
 if(APPLE)
 	set_property(SOURCE ${CMAKE_SOURCE_DIR}/common/SC_DirUtils.cpp PROPERTY COMPILE_FLAGS -xobjective-c++)
@@ -270,6 +281,16 @@ if (NOT WIN32)
 endif()
 
 ## external libraries
+
+# find_package readline is only triggered if linenoise is off
+if(READLINE_FOUND)
+	message(STATUS "Compiling with Readline support")
+	target_compile_definitions(libsclang PUBLIC HAVE_READLINE)
+	target_include_directories(libsclang PUBLIC ${READLINE_INCLUDE_DIR})
+	target_link_libraries(libsclang ${READLINE_LIBRARY})
+endif(READLINE_FOUND)
+mark_as_advanced(READLINE_INCLUDE_DIR READLINE_LIBRARY)
+
 if (APPLE)
 	target_link_libraries(libsclang "-framework Carbon")
 	target_link_libraries(libsclang "-framework CoreAudio")
@@ -342,6 +363,14 @@ elseif(WIN32)
     if(FFTW3F_LIBRARY_DIR)
       list(APPEND SC_WIN_DLL_DIRS "${FFTW3F_LIBRARY_DIR}")
     endif(FFTW3F_LIBRARY_DIR)
+    if(READLINE_LIBRARY_DIR)
+      file(GLOB READLINE_DLL "${READLINE_LIBRARY_DIR}/*readline*.dll")
+      list(APPEND SC_WIN_DLL_DIRS "${READLINE_LIBRARY_DIR}")
+      add_custom_command(TARGET sclang
+          POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E copy_if_different "${READLINE_DLL}" $<TARGET_FILE_DIR:sclang>
+      )
+    endif(READLINE_LIBRARY_DIR)
     if(QT_BIN_PATH)
       list(APPEND SC_WIN_DLL_DIRS "${QT_BIN_PATH}")
     endif(QT_BIN_PATH)

--- a/lang/LangSource/SC_TerminalClient.h
+++ b/lang/LangSource/SC_TerminalClient.h
@@ -31,7 +31,9 @@
 #include "SC_StringBuffer.h"
 #include "SC_Lock.h"
 
+#ifdef USE_LINENOISE
 #include <future>
+#endif
 
 #include <boost/array.hpp>
 #include <boost/asio.hpp>
@@ -142,10 +144,17 @@ protected:
 
 private:
 	// NOTE: called from input thread:
+#ifdef HAVE_READLINE
+	static void readlineInit();
+	static void readlineFunc(SC_TerminalClient *);
+	static int readlineRecompile(int, int);
+	static void readlineCmdLine(char *cmdLine);
+#elif USE_LINENOISE
 	static void linenoiseInit();
 	static void linenoiseRecompile();
 	static void linenoiseQuit();
 	void startInputRead_();
+#endif
 
 	static void *pipeFunc( void * );
 	void pushCmdLine( const char *newData, size_t size );
@@ -182,11 +191,16 @@ private:
 	void startInputRead();
 	void onInputRead(const boost::system::error_code& error, std::size_t bytes_transferred);
 
+#ifdef USE_LINENOISE
 	std::future<void> m_future;
 
 	// command input
 	bool mUseLinenoise;
 	static bool mWantsToExit;
+#else
+	bool mUseReadline;
+	boost::sync::semaphore mReadlineSem;
+#endif
 };
 
 #endif // SC_TERMINALCLIENT_H_INCLUDED


### PR DESCRIPTION
This will use linenoise on Windows and readline on Mac and Linux by default. On all platforms the previous behaviour (use readline if library available) can be achieved by setting SC_LINENOISE=OFF. Also linenoise can be used on Mac and Linux by setting it ON.

Tested on Win-VS2015, Win-MSYS2, Linux and Mac ;)
